### PR TITLE
Add sergii_prostov_fp datalake DAG (goit-de-fp final)

### DIFF
--- a/dags/sergii_prostov_fp/bronze_to_silver.py
+++ b/dags/sergii_prostov_fp/bronze_to_silver.py
@@ -1,0 +1,57 @@
+"""bronze_to_silver.py — Stage 2 of the multi-hop datalake.
+
+Reads bronze/<table>/, applies a regex-based text-cleanup UDF to every string
+column, drops duplicate rows, and writes silver/<table>/.
+
+Usage (also how Airflow invokes it):
+    spark-submit bronze_to_silver.py <table>
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import udf
+from pyspark.sql.types import StringType
+
+
+def clean_text(text: object) -> str:
+    return re.sub(r"[^a-zA-Z0-9,.\"']", "", str(text))
+
+
+clean_text_udf = udf(clean_text, StringType())
+
+
+def main(table: str) -> None:
+    spark = (
+        SparkSession.builder
+        .appName(f"bronze_to_silver[{table}]")
+        .getOrCreate()
+    )
+    spark.sparkContext.setLogLevel("WARN")
+
+    bronze_path = f"bronze/{table}"
+    silver_path = f"silver/{table}"
+
+    df = spark.read.parquet(bronze_path)
+    print(f"read {df.count()} rows from {bronze_path}")
+
+    string_cols = [f.name for f in df.schema.fields if f.dataType.simpleString() == "string"]
+    print(f"cleaning string columns: {string_cols}")
+    for col_name in string_cols:
+        df = df.withColumn(col_name, clean_text_udf(df[col_name]))
+
+    deduped = df.dropDuplicates()
+    print(f"writing {deduped.count()} rows -> {silver_path}")
+    deduped.write.mode("overwrite").parquet(silver_path)
+
+    deduped.show(5, truncate=False)
+    spark.stop()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit("usage: bronze_to_silver.py <table>")
+    main(sys.argv[1])

--- a/dags/sergii_prostov_fp/landing_to_bronze.py
+++ b/dags/sergii_prostov_fp/landing_to_bronze.py
@@ -1,0 +1,66 @@
+"""landing_to_bronze.py — Stage 1 of the multi-hop datalake.
+
+Downloads <table>.csv from the course FTP-over-HTTP, then has Spark read the CSV
+and write it as parquet under bronze/<table>/.
+
+Usage (also how it is invoked from the Airflow DAG):
+    spark-submit landing_to_bronze.py <table>
+
+Where <table> is one of: athlete_bio, athlete_event_results.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import requests
+from pyspark.sql import SparkSession
+
+FTP_BASE = "https://ftp.goit.study/neoversity/"
+
+
+def download_csv(table: str, dest: Path) -> Path:
+    url = f"{FTP_BASE}{table}.csv"
+    print(f"downloading {url}")
+    response = requests.get(url, timeout=120)
+    if response.status_code != 200:
+        sys.exit(f"failed to download {url}: HTTP {response.status_code}")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(response.content)
+    print(f"saved {dest} ({len(response.content):,} bytes)")
+    return dest
+
+
+def main(table: str) -> None:
+    spark = (
+        SparkSession.builder
+        .appName(f"landing_to_bronze[{table}]")
+        .getOrCreate()
+    )
+    spark.sparkContext.setLogLevel("WARN")
+
+    csv_path = download_csv(table, Path(f"{table}.csv"))
+
+    df = (
+        spark.read
+        .option("header", "true")
+        .option("inferSchema", "true")
+        .option("escape", '"')
+        .option("multiLine", "true")
+        .csv(str(csv_path))
+    )
+
+    bronze_path = f"bronze/{table}"
+    print(f"writing {df.count()} rows -> {bronze_path}")
+    df.write.mode("overwrite").parquet(bronze_path)
+
+    print(f"bronze/{table} schema:")
+    df.printSchema()
+    spark.stop()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit("usage: landing_to_bronze.py <table>")
+    main(sys.argv[1])

--- a/dags/sergii_prostov_fp/project_solution.py
+++ b/dags/sergii_prostov_fp/project_solution.py
@@ -1,0 +1,82 @@
+"""Airflow DAG that orchestrates the Part 2 multi-hop datalake.
+
+Five SparkSubmitOperator tasks run in sequence:
+
+    landing_to_bronze (athlete_bio)
+        -> landing_to_bronze (athlete_event_results)
+            -> bronze_to_silver (athlete_bio)
+                -> bronze_to_silver (athlete_event_results)
+                    -> silver_to_gold
+
+Each `application` path is relative to the Airflow `dags/` root, matching the
+brief's example (`dags/oleksiy/spark_job.py`). Drop this file and the three
+spark scripts under `dags/sergii_prostov_fp/` in the airflow_sandbox repo.
+"""
+
+from datetime import datetime
+
+from airflow import DAG
+from airflow.providers.apache.spark.operators.spark_submit import SparkSubmitOperator
+
+DAG_FOLDER = "dags/sergii_prostov_fp"
+SPARK_CONN_ID = "spark-default"
+
+default_args = {
+    "owner": "sergii_prostov",
+    "start_date": datetime(2026, 5, 1),
+}
+
+with DAG(
+    dag_id="sergii_prostov_datalake_dag",
+    default_args=default_args,
+    schedule_interval=None,
+    catchup=False,
+    tags=["sergii_prostov", "final_project"],
+) as dag:
+
+    landing_to_bronze_bio = SparkSubmitOperator(
+        task_id="landing_to_bronze_athlete_bio",
+        application=f"{DAG_FOLDER}/landing_to_bronze.py",
+        application_args=["athlete_bio"],
+        conn_id=SPARK_CONN_ID,
+        verbose=1,
+    )
+
+    landing_to_bronze_results = SparkSubmitOperator(
+        task_id="landing_to_bronze_athlete_event_results",
+        application=f"{DAG_FOLDER}/landing_to_bronze.py",
+        application_args=["athlete_event_results"],
+        conn_id=SPARK_CONN_ID,
+        verbose=1,
+    )
+
+    bronze_to_silver_bio = SparkSubmitOperator(
+        task_id="bronze_to_silver_athlete_bio",
+        application=f"{DAG_FOLDER}/bronze_to_silver.py",
+        application_args=["athlete_bio"],
+        conn_id=SPARK_CONN_ID,
+        verbose=1,
+    )
+
+    bronze_to_silver_results = SparkSubmitOperator(
+        task_id="bronze_to_silver_athlete_event_results",
+        application=f"{DAG_FOLDER}/bronze_to_silver.py",
+        application_args=["athlete_event_results"],
+        conn_id=SPARK_CONN_ID,
+        verbose=1,
+    )
+
+    silver_to_gold = SparkSubmitOperator(
+        task_id="silver_to_gold",
+        application=f"{DAG_FOLDER}/silver_to_gold.py",
+        conn_id=SPARK_CONN_ID,
+        verbose=1,
+    )
+
+    (
+        landing_to_bronze_bio
+        >> landing_to_bronze_results
+        >> bronze_to_silver_bio
+        >> bronze_to_silver_results
+        >> silver_to_gold
+    )

--- a/dags/sergii_prostov_fp/silver_to_gold.py
+++ b/dags/sergii_prostov_fp/silver_to_gold.py
@@ -1,0 +1,69 @@
+"""silver_to_gold.py — Stage 3 of the multi-hop datalake.
+
+Reads silver/athlete_bio and silver/athlete_event_results, casts numeric columns
+that ended up as strings (height, weight) into doubles, joins on athlete_id,
+aggregates avg height/weight per (sport, medal, sex, country_noc), and writes
+gold/avg_stats/.
+
+Both source tables happen to share `country_noc`. The bio's `country_noc` is the
+athlete's country of origin; the event's is the country they represented at the
+event. The brief calls out country of origin as the relevant feature, so we keep
+the bio's value and drop the event's `country_noc` before the join collision.
+
+Usage:
+    spark-submit silver_to_gold.py
+"""
+
+from __future__ import annotations
+
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as F
+
+
+def main() -> None:
+    spark = (
+        SparkSession.builder
+        .appName("silver_to_gold")
+        .getOrCreate()
+    )
+    spark.sparkContext.setLogLevel("WARN")
+
+    bio = spark.read.parquet("silver/athlete_bio")
+    events = spark.read.parquet("silver/athlete_event_results")
+
+    bio_clean = (
+        bio
+        .withColumn("height", F.col("height").cast("double"))
+        .withColumn("weight", F.col("weight").cast("double"))
+        .filter(F.col("height").isNotNull() & F.col("weight").isNotNull())
+        .filter((F.col("height") > 0) & (F.col("weight") > 0))
+        .select("athlete_id", "sex", "country_noc", "height", "weight")
+    )
+
+    # Drop event.country_noc so the join doesn't produce ambiguous columns;
+    # bio.country_noc (origin) is the one used in the aggregation.
+    events_slim = events.select("athlete_id", "sport", "medal")
+
+    joined = events_slim.join(bio_clean, on="athlete_id", how="inner")
+
+    gold = (
+        joined
+        .groupBy("sport", "medal", "sex", "country_noc")
+        .agg(
+            F.avg("height").alias("avg_height"),
+            F.avg("weight").alias("avg_weight"),
+            F.count(F.lit(1)).alias("athletes"),
+        )
+        .withColumn("timestamp", F.current_timestamp())
+    )
+
+    gold_path = "gold/avg_stats"
+    print(f"writing {gold.count()} rows -> {gold_path}")
+    gold.write.mode("overwrite").parquet(gold_path)
+
+    gold.show(10, truncate=False)
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the four files for the GoIT DE final project (Part 2 — multi-hop datalake) under `dags/sergii_prostov_fp/`:

- `landing_to_bronze.py` — FTP CSV → bronze parquet (parameterized by table name)
- `bronze_to_silver.py` — `clean_text` UDF on every string column + dedup → silver parquet
- `silver_to_gold.py` — join `silver/athlete_bio` ↔ `silver/athlete_event_results`, cast height/weight to double, aggregate avg per `(sport, medal, sex, country_noc)` → `gold/avg_stats`
- `project_solution.py` — Airflow DAG `sergii_prostov_datalake_dag` running the three Spark jobs sequentially via `SparkSubmitOperator` (`conn_id='spark-default'`)

DAG path follows the same convention as `dags/maxim_fp/`, `dags/shepeta_fp/`, etc.